### PR TITLE
fix: Change to return influxdb history data list

### DIFF
--- a/src/services/service.device.js
+++ b/src/services/service.device.js
@@ -56,34 +56,36 @@ export const getHistoryFromDevices = async (token, devices, params = '') => {
 
 export const getInfluxDataFromDevices = async (token, devices, params) => {
   const promises = [];
+  const attributes = [];
 
-  devices.forEach(({ deviceID, dynamicAttrs }) => {
+  devices.forEach(({deviceID, dynamicAttrs}) => {
     if (dynamicAttrs) {
-      const newPromises = dynamicAttrs.map(async (attr) => {
-        const { data } = await axios.get(
+      dynamicAttrs.forEach((attr) => {
+        const promise = axios.get(
           `${baseURL}/tss/v1/devices/${deviceID}/attrs/${attr}/data?order=desc${params}`,
-          getHeader(token),
-        );
-
-        const [firstAttrData] = data.data;
-
-        return {
-          attr,
-          // We don't have the metadata on InfluxDB, but its here just to ensure
-          // that this function returns the same data as getHistoryFromDevices
-          metadata: {},
-          device_id: deviceID,
-          ts: firstAttrData.ts,
-          value: firstAttrData.value,
-        };
+          getHeader(token)
+        ).then((response) => {
+          if (!!response.data.data && Array.isArray(response.data.data)) {
+            response.data.data.forEach(attrItems => {
+                attributes.push(
+              {
+                attr,
+                // We don't have the metadata on InfluxDB, but its here just to ensure
+                // that this function returns the same data as getHistoryFromDevices
+                metadata: {},
+                device_id: deviceID,
+                ...attrItems,
+              });
+            });
+          }
+        }).catch(() => Promise.resolve(null));
+        promises.push(promise);
       });
-
-      promises.push(...newPromises);
     }
   });
-
-  return Promise.all(promises);
-};
+  await (Promise.all(promises));
+  return attributes;
+}
 
 export const getDevicesByTemplate = async (token, templates) => {
   const promises = [];


### PR DESCRIPTION
* **Please check if the PR fulfills these requirements**
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
Bug fix


* **What is the current behavior?** (You can also link to an open issue here)
the history query always returns a single value


* **What is the new behavior (if this is a feature change)?**
a list of values is returned


* **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)
No

* **Is there any issue related to this PR in other repository?** (such as dojot/dojot)
[DOJOT-145](https://dojot.atlassian.net/jira/software/c/projects/DOJOT/boards/3?modal=detail&selectedIssue=DOJOT-145)

* **Other information**:
