### PR TITLE
Adiciona variável de ambiente para controle do nível de log

### DIFF
--- a/src/config.js
+++ b/src/config.js
@@ -1,6 +1,8 @@
 
 const config = {
   port: process.env.BS_PORT || 3005,
+  log_level: process.env.BS_LOG_CONSOLE_LEVEL || 'info',
+
   backstage_base_url: process.env.BS_BASE_URL || 'http://localhost:8000',
   graphql_base_url: process.env.BS_GRAPHQL_BASE_URL || 'http://apigw:8000',
   use_influxdb: process.env.BS_USE_INFLUXDB === 'true' || false,

--- a/src/index.js
+++ b/src/index.js
@@ -1,6 +1,7 @@
 import express from 'express';
 import bodyParser from 'body-parser';
 
+import LOG from './utils/Log.js';
 import config from './config.js';
 import graphQLRoutes from './routers/GraphQL.js';
 import keycloakRoutes from './routers/Keycloak.js';
@@ -21,10 +22,11 @@ app.use(sessionTokenGetter);
 app.use(graphQLRoutes);
 
 const server = app.listen(config.port, () => {
-  console.log(`Server running on port ${config.port}`);
+  LOG.debug(`Service started with configs \n${JSON.stringify(config, null, '\t')}`);
+  LOG.info(`Server running on port ${config.port}`);
 });
 
 sessionRedisClient.connect().catch((error) => {
-  console.error(error);
+  LOG.error(error);
   server.close(); // Closes the express server if fails to connect to redis
 });

--- a/src/utils/Log.js
+++ b/src/utils/Log.js
@@ -1,6 +1,6 @@
 import log4js from 'log4js';
 
-import config from '../config.js'
+import config from '../config.js';
 
 log4js.configure({
   appenders: { out: { type: 'stdout', layout: { type: 'basic' } } },

--- a/src/utils/Log.js
+++ b/src/utils/Log.js
@@ -1,8 +1,10 @@
 import log4js from 'log4js';
 
+import config from '../config.js'
+
 log4js.configure({
   appenders: { out: { type: 'stdout', layout: { type: 'basic' } } },
-  categories: { default: { appenders: ['out'], level: 'info' } },
+  categories: { default: { appenders: ['out'], level: config.log_level } },
 });
 
 const Log = log4js.getLogger('BackStage');


### PR DESCRIPTION
Na necessidade de debugar o backstage, percebi que o log level está cravado como 'info', ainda que no docker-compose já tenhamos a variável de ambiente BS_LOG_CONSOLE_LEVEL

Aproveitei para estreiar o LOG.debug adicionando o registro da configuração com a qual o serviço iniciou