### PR TITLE
Cria nova variável para habilitar a interface gráfica

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,8 @@ Documentation for development: https://dojot.github.io/backstage/development/
 | Key                               | Purpose                        | Default Value              | Valid Values |
 | --------------------------------- | ------------------------------ | -------------------------- | ------------ |
 | BS_PORT                           | Backstage port                 | 3005                       | Integer      |
+| BS_LOG_CONSOLE_LEVEL              | Logging level                  | info                       | String       |
+| BS_ENABLE_GRAPHQL_INTERFACE       | Enable GraphQL UI              | false                      | Boolean      |
 | BS_BASE_URL                       | Backstage base URL             | http://localhost:8000      | String       |
 | BS_GRAPHQL_BASE_URL               | Backstage graphql base url     | http://apigw:8000          | String       |
 | BS_POSTGRES_PORT                  | Postgres port                  | 5432                       | Integer      |

--- a/src/config.js
+++ b/src/config.js
@@ -2,6 +2,7 @@
 const config = {
   port: process.env.BS_PORT || 3005,
   log_level: process.env.BS_LOG_CONSOLE_LEVEL || 'info',
+  enable_graphiql: process.env.BS_ENABLE_GRAPHQL_INTERFACE === 'true' || false,
 
   backstage_base_url: process.env.BS_BASE_URL || 'http://localhost:8000',
   graphql_base_url: process.env.BS_GRAPHQL_BASE_URL || 'http://apigw:8000',

--- a/src/routers/GraphQL.js
+++ b/src/routers/GraphQL.js
@@ -2,7 +2,7 @@ import { Router } from 'express';
 import { graphqlHTTP } from 'express-graphql';
 
 import rootSchema from '../Schema.js';
-import config from '../config.js'
+import config from '../config.js';
 
 const router = Router();
 

--- a/src/routers/GraphQL.js
+++ b/src/routers/GraphQL.js
@@ -2,12 +2,13 @@ import { Router } from 'express';
 import { graphqlHTTP } from 'express-graphql';
 
 import rootSchema from '../Schema.js';
+import config from '../config.js'
 
 const router = Router();
 
 router.use('/backstage/graphql', graphqlHTTP({
   schema: rootSchema,
-  graphiql: false,
+  graphiql: config.enable_graphiql,
   customFormatErrorFn: (error) => {
     let data;
     if (


### PR DESCRIPTION
Como o backstage é nosso servidor graphql, às vezes é útil ter acesso diretamente à UI que facilita a navegação pelas nossas entidades/queries/mutations (principalmente pra quem é só backend).
A ideia desse PR é adicionar uma variável de ambiente para controlar a disponibilização dessa interface, que hoje está cravada como 'false'

Aproveitei para adicionar no README a variável de ambiente do PR https://github.com/dojot/backstage/pull/160, que esqueci