### PR TITLE
Adiciona registro de erro de GraphQL no log

### DIFF
--- a/src/routers/GraphQL.js
+++ b/src/routers/GraphQL.js
@@ -1,6 +1,8 @@
 import { Router } from 'express';
 import { graphqlHTTP } from 'express-graphql';
 
+import LOG from '../utils/Log.js';
+
 import rootSchema from '../Schema.js';
 import config from '../config.js';
 
@@ -10,6 +12,7 @@ router.use('/backstage/graphql', graphqlHTTP({
   schema: rootSchema,
   graphiql: config.enable_graphiql,
   customFormatErrorFn: (error) => {
+    LOG.error(error);
     let data;
     if (
       error.originalError


### PR DESCRIPTION
Nos cenários onde o graphql quebra, o erro é parseado e retornado ao front-end, mas em nenhum momento é registrado no log do serviço.
Este PR adiciona o log.error antes de tratar o objeto de erro.