### PR TITLE
remove db from databaseOptions in db/index.js

### DIFF
--- a/src/db/index.js
+++ b/src/db/index.js
@@ -5,7 +5,6 @@ import LOG from '../utils/Log.js';
 const databaseOptions = {
   user: config.postgres_backstage_user,
   host: config.postgres_backstage_host,
-  database: config.postgres_backstage_database,
   password: config.postgres_backstage_pwd,
   port: config.postgres_backstage_port,
 };


### PR DESCRIPTION
This PR fix a error on the backstage initialization:

[ERROR] BackStage - error: database "dojot_dash_users" does not exist
at Parser.parseErrorMessage (/opt/backstage/node_modules/pg-protocol/dist/parser.js:287:98)
at Parser.handlePacket (/opt/backstage/node_modules/pg-protocol/dist/parser.js:126:29)
at Parser.parse (/opt/backstage/node_modules/pg-protocol/dist/parser.js:39:38)
at Socket. (/opt/backstage/node_modules/pg-protocol/dist/index.js:11:42)
at Socket.emit (node:events:513:28)
at addChunk (node:internal/streams/readable:315:12)
at readableAddChunk (node:internal/streams/readable:289:9)
at Socket.Readable.push (node:internal/streams/readable:228:10)
at TCP.onStreamRead (node:internal/stream_base_commons:190:23) {
length: 94,
severity: 'FATAL',
code: '3D000',
detail: undefined,
hint: undefined,
position: undefined,
internalPosition: undefined,
internalQuery: undefined,
where: undefined,
schema: undefined,
table: undefined,
column: undefined,
dataType: undefined,
constraint: undefined,
file: 'postinit.c',
line: '826',
routine: 'InitPostgres'
}